### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ This project requires the following dependencies:
 
 ### Installation
 
-Build aws-eks-with-cillium-karpenter from the source and intsall dependencies:
+Build aws-eks-with-cillium-karpenter from the source and install dependencies:
 
 1. **Clone the repository:**
 


### PR DESCRIPTION
## Summary
- fix an installation section typo in README

## Testing
- `grep -n "install dependencies" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_683f95a70bec832d8642f1e52fc6b5bf