### PR TITLE
Fix comment for bootstrap_cluster_creator_admin_permissions

### DIFF
--- a/eks_cluster.tf
+++ b/eks_cluster.tf
@@ -5,7 +5,7 @@ resource "aws_eks_cluster" "cluster" {
 
   access_config {
     authentication_mode                         = var.eks.authentication_mode                         // Default "API", CONFIG_MAP is deprecated
-    bootstrap_cluster_creator_admin_permissions = var.eks.bootstrap_cluster_creator_admin_permissions // Default false
+    bootstrap_cluster_creator_admin_permissions = var.eks.bootstrap_cluster_creator_admin_permissions // Default true
   }
 
   vpc_config {


### PR DESCRIPTION
## Summary
- correct default comment in `eks_cluster.tf`
- run terraform fmt

## Testing
- `terraform fmt eks_cluster.tf`

------
https://chatgpt.com/codex/tasks/task_e_683f95c0df58832d95d4b5450599ca32